### PR TITLE
Add: added navbar highlighting for active page

### DIFF
--- a/src/components/autocomplete.js
+++ b/src/components/autocomplete.js
@@ -51,6 +51,7 @@ const renderItem = (title, count) => ({
 
 const Complete = ({options=[]}) => (
     <AutoComplete
+        disabled
         dropdownClassName="certain-category-search-dropdown"
         dropdownMatchSelectWidth={500}
         style={{

--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -9,9 +9,9 @@ import { useHistory } from "react-router";
 
 const styles = {
 	border: {
-		borderBottomColor: "red",
 		fontWeight: "bold",
-		border: 'none'
+		border: 'none',
+		color: "#fff"
 	},
 	autoComplete: {
 		width: "35%",
@@ -19,15 +19,24 @@ const styles = {
 	},
 	menuStyle: {
 		display: "flex",
-		justifyContent: "space-between",
+		justifyContent: "space-around",
 		alignItems: "center",
 		backgroundColor: "rgba(152,171,196,0.98)",
 	},
 	navButtonStyle: {
 		color: "black",
 		fontWeight: 600,
-	}
+	},
+	activeNavItemStyle: {
+		color: "#fff",
+		fontWeight: 600,
+		backgroundColor: "#7c8fa9",
+		borderRadius: 8
+	},
 }
+
+const repositories = "repositories"
+const explore = "explore"
 
 const NavBar = () => {
 	const loc = useHistory();
@@ -37,19 +46,42 @@ const NavBar = () => {
 		loc.push('/')
 	}
 
+	const getActiveNavItemStyle = (who) => {
+		switch (who) {
+			case repositories:
+				if (loc.location.pathname === "/" + who) {
+					return styles.activeNavItemStyle
+				}
+
+				return styles.navButtonStyle
+			case explore:
+				if (loc.location.pathname === "/" + who) {
+					return styles.activeNavItemStyle
+				}
+
+				return styles.navButtonStyle
+			default:
+				return styles.navButtonStyle
+		}
+	}
+
+	const handleNavigation = (where) => {
+		loc.push(where)
+	}
+
 
 	return <Menu style={styles.menuStyle} mode="horizontal">
-		<Menu.Item style={styles.border} key="openregistry" icon={<img src={parachute} style={{ height: 50 }} alt={""} />}>
-			<Button size="small" type="link" style={styles.navButtonStyle} onClick={() => loc.push('/repositories')}>OpenRegistry</Button>
+		<Menu.Item style={styles.border} key="open-registry" icon={<img src={parachute} style={{ height: 50 }} alt={""} />}>
+			<Button size="small" type="link" style={styles.navButtonStyle} onClick={() => handleNavigation(repositories)}>OpenRegistry</Button>
 		</Menu.Item>
 		<Menu.Item style={styles.autoComplete} key="Search">
 			<Complete />
 		</Menu.Item>
-		<Menu.Item style={styles.border} key="Repositories">
-			<Button size="small" type="link" onClick={() => loc.push('/repositories')} style={styles.navButtonStyle}>Repositories</Button>
+		<Menu.Item style={getActiveNavItemStyle(repositories)} key="Repositories">
+			<Button size="small" type="link" onClick={() => handleNavigation(repositories)} style={getActiveNavItemStyle(repositories)}>Repositories</Button>
 		</Menu.Item>
-		<Menu.Item style={styles.border} key="Explore">
-			<Button size="small" type="link" onClick={() => loc.push('/explore')} style={styles.navButtonStyle}>Explore</Button>
+		<Menu.Item style={getActiveNavItemStyle(explore)} key="Explore">
+			<Button size="small" type="link" onClick={() => handleNavigation(explore)} style={getActiveNavItemStyle(explore)}>Explore</Button>
 		</Menu.Item>
 		<Menu.Item style={styles.border} key="Help">
 			<Button
@@ -66,7 +98,5 @@ const NavBar = () => {
 			<Button size="small" icon={<UserOutlined />} type="link" onClick={logOut} style={styles.navButtonStyle}>Log Out</Button>
 		</Menu.Item>
 	</Menu>
-
 }
-
 export default NavBar;

--- a/src/pages/image_detail.js
+++ b/src/pages/image_detail.js
@@ -38,7 +38,7 @@ with a colon, like the \`:id\` param defined in`
                             })
                         }
                     </div>
-                    <Text strong copyable code>{`docker pull ${username}/${imagename}`}</Text>
+                    <Text strong copyable code>{`docker pull openregistry.dev/${username}/${imagename}`}</Text>
                 </div>
             </Card>
             <Card style={{width: "90%", marginTop: "2%"}}>

--- a/src/pages/landingPage.js
+++ b/src/pages/landingPage.js
@@ -185,7 +185,7 @@ export const CustomButton = (
 		case "solid":
 			return <Button icon={icon} onClick={onClick} disabled={disabled} size={size} type="primary">{label}</Button>
 		case "outlined":
-			return <Button icon={icon} onClick={onClick} disabled={disabled} style={{ borderRadius: 10, "&:hover": { backgroundColor: "pink" } }} size={size} type="primary">{label}</Button>
+			return <Button icon={icon} onClick={onClick} disabled={disabled} size={size} type="primary">{label}</Button>
 		default:
 			return <Button onClick={onClick} disabled={disabled} style={{ width: "100%" }} size={size} type="primary">{label}</Button>
 	}

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -16,23 +16,17 @@ export const ParachuteUIRouter = () => {
 	return (
 		<Router>
 			<Switch>
-				<Route path="/repositories">
-					<AuthRoute>
-						<PersonalDashboard />
-					</AuthRoute>
-				</Route>
-				<Route path={"/details/:username/:imagename"}>
-					<Wrapper>
-						<ImageDetail />
-					</Wrapper>
-				</Route>
-				<Route path="/explore">
-					<Wrapper>
-						<ExploreContainerImages />
-					</Wrapper>
-				</Route>
-				<Route path="/login" component={LandingPage} />
-				<Route path="/profile" />
+				<AuthRoute path="/repositories">
+					<PersonalDashboard />
+				</AuthRoute>
+				<AuthRoute path={"/details/:username/:imagename"}>
+					<ImageDetail />
+				</AuthRoute>
+				<AuthRoute path="/explore">
+					<ExploreContainerImages />
+				</AuthRoute>
+				{/*<Route path="/login" component={LandingPage} />*/}
+				{/*<Route path="/profile" />*/}
 				<Route path="/" component={LandingPage} />
 			</Switch>
 		</Router>
@@ -43,7 +37,7 @@ const Wrapper = ({ children, ...rest }) => {
 	return (
 		<Route
 			{...rest}
-			render={({ location }) =>
+			render={() =>
 				<React.Fragment>
 					<NavBar />
 					{children}
@@ -60,11 +54,7 @@ export const IsTokenValid = () => {
 	}
 	const decoded = jwt_decode(token)
 
-	if (decoded.exp * 1000 > new Date().getTime()) {
-		return true
-	}
-
-	return false
+	return decoded.exp * 1000 > new Date().getTime();
 }
 
 const AuthRoute = ({ children, ...rest }) => {

--- a/src/styles/landingpage.css
+++ b/src/styles/landingpage.css
@@ -292,8 +292,8 @@ span {
 }
 
 .ant-btn-primary:hover {
-    background: #88a4c2;
-    border-color: #88a4c2;
+    background: #7c8fa9;
+    border-color: #7c8fa9;
 }
 
 


### PR DESCRIPTION
When we navigate to a page, say `/repositories`, now the repositories link
in navbar will be highlighted, making more visual about what tab is
active.

Also minor improvements here n there

Here's how it looks  like:
![Screenshot 2021-10-23 at 11 17 52 AM](https://user-images.githubusercontent.com/10788442/138544316-032629f6-aff3-46e7-8400-28a51bf74427.png)

Signed-off-by: jay-dee7 <jasdeepsingh.uppal@gmail.com>