### PR TITLE
Fix copy env.example step

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install # or yarn install
 
 3. Make a copy of the `env.example` file:
 ```sh
-cp env.example .env
+cp .env.example .env
 ```
 
 > Note that here you must make sure you have the **OpenRegistry Backend** running on your local system.


### PR DESCRIPTION
## WHY

Because the correct env's sample file is `.env.example`. This PR fix that 🙏 